### PR TITLE
chore: upgraded openrest4j to 1.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 	
 
     <properties>
-		<openrest4j.version>1.32.0</openrest4j.version>
+		<openrest4j.version>1.36.0</openrest4j.version>
 		<com.wix.restaurants.availability.version>1.9.0</com.wix.restaurants.availability.version>
 		<com.wix.restaurants.authentication.version>1.12.0</com.wix.restaurants.authentication.version>
         <com.wix.rest.rest-rfc7807.version>1.0.0</com.wix.rest.rest-rfc7807.version>


### PR DESCRIPTION
Some of the conditions (for example, `order_coupon`) were not included into current openrest4j version although API was returning them. Newer version of the library contains them.

Please release new version of the SDK